### PR TITLE
Fix/wyc/goorm 104 order service api error debuging

### DIFF
--- a/src/main/java/profect/group1/goormdotcom/cart/controller/internal/v1/CartInternalController.java
+++ b/src/main/java/profect/group1/goormdotcom/cart/controller/internal/v1/CartInternalController.java
@@ -23,7 +23,7 @@ public class CartInternalController implements CartInternalApiDocs {
 
 	@PostMapping
 	public ApiResponse<UUID> createCart(
-			@RequestHeader UUID userId
+			@RequestHeader(value = "User-Id", required = true) UUID userId
 	) {
 		UUID cartId = cartService.createCart(userId);
 

--- a/src/test/java/profect/group1/goormdotcom/cart/controller/CartInternalControllerTest.java
+++ b/src/test/java/profect/group1/goormdotcom/cart/controller/CartInternalControllerTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpHeaders;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import profect.group1.goormdotcom.cart.controller.internal.v1.CartInternalController;
@@ -51,12 +52,12 @@ public class CartInternalControllerTest {
     void createCart() throws Exception {
         // given
         UUID cartId = UUID.randomUUID();
-        given(loginUserArgumentResolver.supportsParameter(any())).willReturn(true);
-        given(loginUserArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(userId);
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("User-Id", userId.toString());
         given(cartService.createCart(userId)).willReturn(cartId);
 
         // when & then
-        mockMvc.perform(post("/internal/v1/carts"))
+        mockMvc.perform(post("/internal/v1/carts").headers(headers))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.result").value(cartId.toString()));
     }


### PR DESCRIPTION
## #️⃣ Issue Number

#15

## 📝 요약(Summary)

1. CartInternalController의 카트 생성 api의 요청 파라미터 수정
2. 테스트 코드의 mock 헤더 주입을 위해 일부 수정

## 📝 리뷰 요청사항

테스트 코드의 검증력을 최대한 해치지 않는 선에서 수정하였습니다.
